### PR TITLE
fix: make the use of `crossterm` unambiguous

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    crossterm::tty::IsTty,
+    ::crossterm::tty::IsTty,
     minimad::{OwningTemplateExpander, TextTemplate},
     termimad::*,
 };

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -1,5 +1,5 @@
 use {
-    crossterm::style::{Attribute::*, Color::*},
+    ::crossterm::style::{Attribute::*, Color::*},
     minimad::Alignment,
     termimad::*,
 };


### PR DESCRIPTION
I had this error while testing `broot` / compiling`glassbench`:

```
error[E0659]: `crossterm` is ambiguous
 --> src/printer.rs:3:5
  |
3 |     crossterm::tty::IsTty,
  |     ^^^^^^^^^ ambiguous name
  |
  = note: ambiguous because of multiple potential import sources
  = note: `crossterm` could refer to a crate passed with `--extern`
  = help: use `::crossterm` to refer to this crate unambiguously
note: `crossterm` could also refer to the module imported here
 --> src/printer.rs:5:5
  |
5 |     termimad::*,
  |     ^^^^^^^^^^^
  = help: use `self::crossterm` to refer to this module unambiguously

error[E0659]: `crossterm` is ambiguous
 --> src/skin.rs:2:5
  |
2 |     crossterm::style::{Attribute::*, Color::*},
  |     ^^^^^^^^^ ambiguous name
  |
  = note: ambiguous because of multiple potential import sources
  = note: `crossterm` could refer to a crate passed with `--extern`
  = help: use `::crossterm` to refer to this crate unambiguously
note: `crossterm` could also refer to the module imported here
 --> src/skin.rs:4:5
  |
4 |     termimad::*,
  |     ^^^^^^^^^^^
  = help: use `self::crossterm` to refer to this module unambiguously
```

This PR fixes this issue.

