### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ cargo bench -- -- --no-save
 The command has the following form:
 
 ```bash
-cargo bench -- <optional list of benchs to run> -- <glassbench arguments>
+cargo bench -- <optional list of benches to run> -- <glassbench arguments>
 ```
 
-The names of the benchs are the names of the bench files (see examples below).
+The names of the benches are the names of the bench files (see examples below).
 
 The glassbench arguments let you display the history or graph the records for a specific task, specify a tag, etc.
 

--- a/src/main_macro.rs
+++ b/src/main_macro.rs
@@ -6,7 +6,7 @@ use crate::*;
 ///
 /// ```no-test
 /// glassbench!(
-///     "Sortings",
+///     "Sorting",
 ///     bench_number_sorting,
 ///     bench_alpha_sorting,
 /// );
@@ -14,7 +14,7 @@ use crate::*;
 ///
 /// This generates the whole main function.
 /// If you want to set the bench name yourself
-/// (not recommanded), or change the way the launch
+/// (not recommended), or change the way the launch
 /// arguments are used, you can write the main
 /// yourself and call [create_bench] and [after_bench]
 /// instead of using this macro.

--- a/src/task_bench.rs
+++ b/src/task_bench.rs
@@ -9,7 +9,7 @@ use {
 /// Number of iterations to do before everything else
 pub const WARMUP_ITERATIONS: usize = 2;
 
-/// Number of iterations to do, after warmup, to estimate the total number
+/// Number of iterations to do, after warm-up, to estimate the total number
 /// of iterations to do
 ///
 /// (regarding real benchmark, it can be considered as part of benchmark)
@@ -53,8 +53,8 @@ impl TaskBench {
 
     /// Call the function to measure
     ///
-    /// There will be an initial warmup, after which
-    /// the function will be called enought times to
+    /// There will be an initial warm-up, after which
+    /// the function will be called enough times to
     /// get a reliable estimation of its duration.
     pub fn iter<M, R>(&mut self, mut measured: M)
     where
@@ -64,7 +64,7 @@ impl TaskBench {
             eprintln!("bench already used - please fix your benchmark");
             return;
         }
-        // just a warmup
+        // just a warm-up
         for _ in 0..WARMUP_ITERATIONS {
             measured();
         }


### PR DESCRIPTION
Found via `codespell -S target,*.js -L crate`